### PR TITLE
fix: removed default for FILES_DIR (#137)

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -64,7 +64,7 @@ export const YML_EXTENSION = process.env.YML_EXT || "yml";
  *  @constant
  *  @type {string}
  */
-export const FILES_DIR = process.env.FILES_DIR || "/";
+export const FILES_DIR = process.env.FILES_DIR;
 
 export const UTF8_DECODER = new TextDecoder();
 


### PR DESCRIPTION
if FILES_DIR doesn't exist the statement will crash. Removed default cause we don't necessary want the statement to work on any deployment
