### PR TITLE
feat: ✨ Pass http request to zencode script

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -144,7 +144,29 @@ export const getData = (req: Request, res: Response) => {
 
   if (req.method === "POST") params = req.body?.data;
 
-  return res.locals?.zenroom_data || params || {};
+  const data = res.locals?.zenroom_data || params || {};
+
+  if (typeof data === 'object') {
+    const httpRequest = {
+      base_url: req.baseUrl,
+      http_version: req.httpVersion,
+      headers: req.headers,
+      path: req.path,
+      method: req.method,
+      protocol: req.protocol,
+      socket: {
+        local_port: req.socket.localPort,
+        local_address: req.socket.localAddress,
+        remote_port: req.socket.remotePort,
+        remote_family: req.socket.remoteFamily,
+        remote_address: req.socket.remoteAddress,
+      },
+    }
+
+    data.http_request = httpRequest;
+  }
+
+  return data
 };
 
 export const isChainLastBlock = (internalResult: SingleInstanceOutput) => {

--- a/packages/core/tests/empty_output.ts
+++ b/packages/core/tests/empty_output.ts
@@ -36,5 +36,5 @@ test.serial("OnSuccess is always executed on empty result", async (t) => {
   t.true(log.calledOnce);
   t.true(log.calledWith("success!"));
   t.is(res.status, 200);
-  t.deepEqual(res.body, []);
+  t.true('http_request' in res.body);
 });

--- a/packages/core/tests/index_test.js
+++ b/packages/core/tests/index_test.js
@@ -417,3 +417,16 @@ test("Check that the middleware is handling if index is not filled for each", as
   t.true(res.body.zenroom_errors.logs.includes("Cannot find 'temp' anywhere"));
   t.is(res.status, 500);
 });
+
+test("Check that zenroom can read http request", async (t) => {
+  const app = express();
+  app.use(bodyParser.json());
+  app.use("/api/*", core);
+
+  const res = await request(app)
+    .post("/api/http_request")
+
+  t.is(res.status, 200);
+  t.true('http_version' in res.body)
+  t.true('remote_address' in res.body)
+});

--- a/packages/core/tests/utils_test.js
+++ b/packages/core/tests/utils_test.js
@@ -147,6 +147,7 @@ test("getContracts works correctly", async (t) => {
     "/hash-test",
     "/http-output",
     "/http-test",
+    "/http_request",
     "/keygen",
     "/planetmint_retrieve",
     "/planetmint_retrieve_no_exist",
@@ -219,14 +220,42 @@ test("Complete message", async (t) => {
   t.is("<h2>404: This contract does not exists</h2>", result);
 });
 
+const generateEmptyRequest = () => {
+  const req = {
+    baseUrl: null, httpVersion: null, headers: null,
+    path: null, method: null, protocol: null,
+    body: { data: null },
+    socket: { localPort: null, localAddress: null,
+              remotePort: null, remoteFamily: null,
+              remoteAddress: null }};
+  const result = {
+    http_request: {
+      base_url: null,
+      headers: null,
+      http_version: null,
+      method: null,
+      path: null,
+      protocol: null,
+      socket: {
+        local_address: null,
+        local_port: null,
+        remote_address: null,
+        remote_family: null,
+        remote_port: null,
+      },
+    },
+  }
+  return { req, result }
+}
+
 test("getData works correctly", (t) => {
-  const req = { body: { data: null } };
+  const { req, result } = generateEmptyRequest();
   const res = { locals: { zenroom_data: null } };
-  t.deepEqual(getData(req, res), {});
+  t.deepEqual(getData(req, res), result);
 });
 
 test("getData with empty request", (t) => {
-  const req = { body: { data: null } };
+  const { req, result } = generateEmptyRequest();
   const res = { locals: { zenroom_data: 42 } };
 
   t.is(42, res.locals.zenroom_data || req.body.data || {});

--- a/test/fixtures/empty.zen
+++ b/test/fixtures/empty.zen
@@ -1,3 +1,3 @@
 Rule unknown ignore
-Given nothing
+Given I have a 'string dictionary' named 'http request'
 Then print all data

--- a/test/fixtures/gpp-sawroom-sample-debug-inplace.yml
+++ b/test/fixtures/gpp-sawroom-sample-debug-inplace.yml
@@ -9,7 +9,7 @@ blocks:
 
       Scenario simple: Generate a random password
 
-      Given nothing
+      Given I have a 'string dictionary' named 'http request'
 
       When I create the random object of '128' bits
       When I rename the 'random_object' to 'myRandom'

--- a/test/fixtures/http_request.zen
+++ b/test/fixtures/http_request.zen
@@ -1,0 +1,4 @@
+Given I have a 'string dictionary' named 'http request'
+When I pickup from path 'http request.http version'
+When I pickup from path 'http request.socket.remote address'
+Then print data

--- a/test/fixtures/single-random.zen
+++ b/test/fixtures/single-random.zen
@@ -2,7 +2,7 @@ rule check version 1.0.0
 
 Scenario simple: Generate a random password
 
-Given nothing
+Given I have a 'string dictionary' named 'http request'
 
 When I create the random object of '128' bits
 When I rename the 'random_object' to 'myRandom'


### PR DESCRIPTION
Each zencode script receive as input a `http request` of the form
```
{
  http_request: {
    base_url: '/api/http_request',
    headers: {
      'accept-encoding': 'gzip, deflate',
      connection: 'close',
      'content-length': '0',
      host: '127.0.0.1:44267'
    },
    http_version: '1.1',
    method: 'POST',
    path: '/',
    protocol: 'http',
    socket: {
      local_address: '::ffff:127.0.0.1',
      local_port: 44267,
      remote_address: '::ffff:127.0.0.1',
      remote_family: 'IPv6',
      remote_port: 59794
    }
  },
}
```

If `http_request` exists in data, it gets overwritten.

Important: EACH contract receives the data as above, thus `Given nothing` canno be used inside restroom